### PR TITLE
Add "Not Started" as Possible Task Status

### DIFF
--- a/threatconnect.js
+++ b/threatconnect.js
@@ -2443,7 +2443,7 @@ function Tasks(authentication) {
     };
 
     this.status = function(data) {
-        if (valueCheck('status', data, ['In Progress', 'Complete', 'Waiting on Someone', 'Deferred'])) {
+        if (valueCheck('status', data, ['Not Started', 'In Progress', 'Complete', 'Waiting on Someone', 'Deferred'])) {
             this.rData.optionalData.status = data;
         }
         return this;


### PR DESCRIPTION
Added "Not Started" as a possible task status (this prevents a warning when trying to create a task with a status of "Not Started").