### PR TITLE
Complete and Systematic Support for File and Custom Indicators

### DIFF
--- a/tests/test/groupTest.js
+++ b/tests/test/groupTest.js
@@ -48,14 +48,37 @@ describe('ThreatConnect Groups', function() {
           groups.commit(done);
         });
       });
-      /* Test retrieve groups. */
-      describe('#retrieve()', function() {
+      /* Test retrieving multiple groups. */
+      describe('#retrieve multiple()', function() {
         it('should retrieve at least one result', function(done) {
           // re-initialize instance of groups class
           var groups = tc.groups();
 
           groups.owner(testOwner)
             .type(groupType)
+            .done(function(response) {
+              // make sure there is at least one group of the current type (we just created one so there should be)
+              assert.isAbove(response.data.length, 0);
+              // make sure there are no errors
+              assert.equal(response.error, undefined);
+            })
+            .error(function(response) {
+              // make sure there are no errors
+              assert.equal(response.error, undefined);
+            });
+
+          groups.retrieve(done);
+        });
+      });
+      /* Test retrieving a specific group. */
+      describe('#retrieve single()', function() {
+        it('should retrieve at least one result', function(done) {
+          // re-initialize instance of groups class
+          var groups = tc.groups();
+
+          groups.owner(testOwner)
+            .type(groupType)
+            .id(groupId)
             .done(function(response) {
               // make sure there is at least one group of the current type (we just created one so there should be)
               assert.isAbove(response.data.length, 0);

--- a/tests/test/indicatorTest.js
+++ b/tests/test/indicatorTest.js
@@ -91,7 +91,16 @@ describe('ThreatConnect Indicators', function() {
               // make sure there is at least one indicator of the current type (we just created one so there should be)
               assert.isAbove(response.data.length, 0);
               // make sure that the indicator is actually returned
-              assert.notEqual(response.data[0].indicators, "");
+              assert.notEqual(response.data[0].indicator, undefined);
+              assert.notEqual(response.data[0].indicator, "");
+
+              // if the current indicator type is a file, make sure the indicator is an Object
+              if (indicatorType.type === "File") {
+                assert.isObject(response.data[0].indicator);
+              } else {  // if the indicator type is not a file, make sure the response is a string
+                assert.isString(response.data[0].indicator);
+              }
+
               // make sure there are no errors
               assert.equal(response.error, undefined);
             })

--- a/tests/test/indicatorTest.js
+++ b/tests/test/indicatorTest.js
@@ -90,6 +90,8 @@ describe('ThreatConnect Indicators', function() {
             .done(function(response) {
               // make sure there is at least one indicator of the current type (we just created one so there should be)
               assert.isAbove(response.data.length, 0);
+              // make sure that the indicator is actually returned
+              assert.notEqual(response.data[0].indicators, "");
               // make sure there are no errors
               assert.equal(response.error, undefined);
             })

--- a/tests/test/indicatorTest.js
+++ b/tests/test/indicatorTest.js
@@ -57,13 +57,36 @@ describe('ThreatConnect Indicators', function() {
         });
       });
       /* Test retrieve indicators. */
-      describe('#retrieve()', function() {
+      describe('#retrieve multiple()', function() {
         it('should retrieve at least one result', function(done) {
           // re-initialize instance of indicators class
           var indicators = tc.indicators();
 
           indicators.owner(testOwner)
             .type(indicatorType)
+            .done(function(response) {
+              // make sure there is at least one indicator of the current type (we just created one so there should be)
+              assert.isAbove(response.data.length, 0);
+              // make sure there are no errors
+              assert.equal(response.error, undefined);
+            })
+            .error(function(response) {
+              // make sure there are no errors
+              assert.equal(response.error, undefined);
+            });
+
+          indicators.retrieve(done);
+        });
+      });
+      /* Test retrieving a specific indicator. */
+      describe('#retrieve single()', function() {
+        it('should retrieve at least one result', function(done) {
+          // re-initialize instance of indicators class
+          var indicators = tc.indicators();
+
+          indicators.owner(testOwner)
+            .type(indicatorType)
+            .indicator(indicator)
             .done(function(response) {
               // make sure there is at least one indicator of the current type (we just created one so there should be)
               assert.isAbove(response.data.length, 0);

--- a/tests/test/indicatorTest.js
+++ b/tests/test/indicatorTest.js
@@ -101,6 +101,30 @@ describe('ThreatConnect Indicators', function() {
           indicators.retrieve(done);
         });
       });
+      /* Test update indicators. */
+      describe('#update()', function() {
+        it('should update without error', function(done) {
+          // re-initialize instance of indicators class
+          var indicators = tc.indicators();
+
+          // test updating the indicator with a threat and confidence rating
+          indicators.owner(testOwner)
+            .indicator(indicator)
+            .type(indicatorType)
+            .rating(3)
+            .confidence(50)
+            .done(function(response) {
+              // make sure there are no errors
+              assert.equal(response.error, undefined);
+            })
+            .error(function(response) {
+              // make sure there are no errors
+              assert.equal(response.error, undefined);
+            });
+
+          indicators.update(done);
+        });
+      });
       /* Test delete indicators. */
       describe('#delete()', function() {
         it('should delete without error', function(done) {

--- a/tests/testrunner.html
+++ b/tests/testrunner.html
@@ -9,7 +9,6 @@
     <!-- Uncomment the line below to use the master version of the SDK -->
     <!-- <script type="text/javascript" src="https://cdn.rawgit.com/ThreatConnect-Inc/threatconnect-javascript/master/threatconnect.js"></script> -->
 
-
     <!-- ThreatConnect configuration file -->
     <script type="text/javascript" src="./tc.conf.js"></script>
 

--- a/threatconnect.js
+++ b/threatconnect.js
@@ -4049,7 +4049,7 @@ var normalize = {
     },
     indicators: function(type, response) {
         var indicators,
-            indicatorsData,
+            indicatorData,
             indicatorTypeData,
             indicatorType = type.type;
 
@@ -4080,27 +4080,27 @@ var normalize = {
 
             if (typeof indicatorTypeData != 'undefined'){
                 indicatorType = indicatorTypeData.type;
-                indicatorsData = {};
+                indicatorData = {};
                 // $.each(type.indicatorFields, function(ikey, ivalue) {
                 Array.prototype.forEach.call(type.indicatorFields, function(ivalue, index, array){
                     if ('summary' in rvalue) {
-                        indicatorsData.summary = rvalue.summary;
+                        indicatorData.summary = rvalue.summary;
                         return false;
                     } else {
                         if (rvalue[ivalue]) {
-                            indicatorsData[ivalue] = rvalue[ivalue];
+                            indicatorData[ivalue] = rvalue[ivalue];
                         }
                     }
                 });
 
                 // If indicator has only one element, return as str
                 if (type.indicatorFields.length == 1) {
-                    indicatorsData = indicatorsData[type.indicatorFields[0]];
+                    indicatorData = indicatorData[type.indicatorFields[0]];
                 }
 
                 indicators.push({
                     id: rvalue.id,
-                    indicator: indicatorsData,
+                    indicator: indicatorData,
                     dateAdded: rvalue.dateAdded,
                     lastModified: rvalue.lastModified,
                     ownerName: rvalue.ownerName || rvalue.owner.name,

--- a/threatconnect.js
+++ b/threatconnect.js
@@ -223,6 +223,7 @@ function getParameterArrayByName(name) {
 
     var qs = location.search;
 
+    // TODO: should the line below be an assignment or conditional expression (e.g. === )? (3)
     while(result = regex.exec(qs)) {
         results[i++] = (result === null ? "" : decodeURIComponent(result[1].replace(/\+/g, " ")));
         qs = qs.substring(result.index + result[0].length);
@@ -479,7 +480,7 @@ function RequestObject() {
     };
 
     this.hasPrevious = function() {
-        if (this.settings.requestCount == 0) {
+        if (this.settings.requestCount === 0) {
             return false;
         }
         return true;
@@ -540,7 +541,7 @@ function RequestObject() {
         console.log('authorization', authorization);
         */
 
-        this.addHeader('Timestamp', timestamp),
+        this.addHeader('Timestamp', timestamp);
         this.addHeader('Authorization', authorization);
     };
 
@@ -610,7 +611,7 @@ function RequestObject() {
                 // console.log('request.getAllResponseHeaders()', request.getAllResponseHeaders());
                 var currentCount = _this.settings.remaining,
                     // upload_pattern = /upload/,
-                    remaining = undefined,
+                    remaining,
                     responseContentType = request.getResponseHeader('Content-Type');
 
                 _this.response.apiCalls++;
@@ -775,9 +776,9 @@ function Db(authentication) {
 
     this.authentication = authentication;
     this.addHeader('DB-Method', 'GET');
-    this.ajax.requestUri = this.ajax.baseUri + '/exchange/db',
-    this.settings.helper = true,
-    this.settings.normalizer = normalize.default,
+    this.ajax.requestUri = this.ajax.baseUri + '/exchange/db';
+    this.settings.helper = true;
+    this.settings.normalizer = normalize.default;
     this.settings.type = undefined;
     this.command = undefined;
     this.domain = undefined;
@@ -841,12 +842,12 @@ function Groups(authentication) {
     RequestObject.call(this);
 
     this.authentication = authentication;
-    this.ajax.requestUri = 'v2',
+    this.ajax.requestUri = 'v2';
     this.resultLimit(500);
-    this.settings.helper = true,
-    this.settings.normalizer = normalize.groups,
-    this.settings.normalizerType = TYPE.GROUP,
-    this.settings.type = TYPE.GROUP,
+    this.settings.helper = true;
+    this.settings.normalizer = normalize.groups;
+    this.settings.normalizerType = TYPE.GROUP;
+    this.settings.type = TYPE.GROUP;
     this.rData = {
         id: undefined,
         associationType: undefined,
@@ -901,7 +902,7 @@ function Groups(authentication) {
 
     /* GROUP DATA OPTIONAL */
     this.attributes = function(data) {
-        if (objectCheck('attributes', data) && data.length != 0) {
+        if (objectCheck('attributes', data) && data.length !== 0) {
             this.rData.optionalData.attribute.push(this.rData.optionalData.attribute, data);
         }
         return this;
@@ -910,7 +911,7 @@ function Groups(authentication) {
     this.tags = function(data) {
         if (this.rData.optionalData.tag) { this.rData.optionalData.tag = []; }
         var tag;
-        if (objectCheck('tag', data) && data.length != 0) {
+        if (objectCheck('tag', data) && data.length !== 0) {
             for (tag in data) {
                 this.rData.optionalData.tag.push({name: data[tag]});
             }
@@ -1368,10 +1369,10 @@ function Indicators(authentication) {
     RequestObject.call(this);
 
     this.authentication = authentication;
-    this.settings.helper = true,
-    this.settings.normalizer = normalize.indicators,
-    this.settings.type = TYPE.INDICATOR,
-    this.settings.normalizerType = TYPE.INDICATOR,
+    this.settings.helper = true;
+    this.settings.normalizer = normalize.indicators;
+    this.settings.type = TYPE.INDICATOR;
+    this.settings.normalizerType = TYPE.INDICATOR;
     this.iData = {
         indicator: undefined,
         optionalData: {},
@@ -1482,9 +1483,9 @@ function Indicators(authentication) {
 
         // raise an error if the user passed in an empty Object
         if (indicatorValue === undefined) {
-            // TODO: raise error here
             var errorMessage = 'Request Failure: indicator is required (an empty Object was received).';
             console.error(errorMessage);
+            this.callbacks.error({error: errorMessage});
         } else {
             return indicatorValue;
         }
@@ -1539,8 +1540,6 @@ function Indicators(authentication) {
     this.commitAssociation = function(association) {
         /* POST - /v2/indicators/{type}/{indicator}/groups/{type}/{id} */
         this.normalization(normalize.find(association.type.type));
-
-        // TODO: add an error here if no indicator is given (2)
 
         // if the indicator is an Object, set the indicator to be one of the values in the Object
         if(this.iData.indicator.constructor == Object) {
@@ -2079,6 +2078,7 @@ function Indicators(authentication) {
             var specificBody = this.iData.specificData[this.settings.type.type];
             this.body($.extend(this.iData.requiredData, $.extend(this.iData.optionalData, specificBody)));
 
+            // TODO: Is the check below necessary? (3)
             if (this.iData.indicator) {
                 this.requestUri([
                     this.ajax.baseUri,
@@ -2108,24 +2108,24 @@ function IndicatorsBatch(authentication) {
     RequestObject.call(this);
 
     this.authentication = authentication;
-    this.batchBody = [],
-    this.ajax.requestUri = 'v2',
-    this.settings.helper = true,
-    this.settings.normalizer = normalize.indicators,
-    this.settings.type = TYPE.INDICATOR,
-    this.settings.normalizerType = TYPE.INDICATOR,
+    this.batchBody = [];
+    this.ajax.requestUri = 'v2';
+    this.settings.helper = true;
+    this.settings.normalizer = normalize.indicators;
+    this.settings.type = TYPE.INDICATOR;
+    this.settings.normalizerType = TYPE.INDICATOR;
     this.batch = {
         action: 'Create',               // Create|Delete
         attributeWriteType: 'Append',   // Append|Replace
         haltOnError: false,             // false|true
         owner: undefined,
-    },
+    };
     this.status = {
         frequency: 1000,                // default: 1 second start
         timeout: 300000,                // default: 5 minutes
         multiplier: 2,                  // default: 2
         maxFrequency: 30000,            // deafult: 30 seconds
-    },
+    };
     this.iData = {
         optionalData: {},
         requiredData: {},
@@ -2179,7 +2179,7 @@ function IndicatorsBatch(authentication) {
     this.attributes = function(data) {
         // if (!this.iData.optionalData.attribute) {this.iData.optionalData.attribute = []}
         // if (typeof data === 'object' && data.length != 0) {
-        if (Object.prototype.toString.call( data ) === '[object Array]' && data.length != 0) {
+        if (Object.prototype.toString.call( data ) === '[object Array]' && data.length !== 0) {
             // this.iData.optionalData.attribute = $.merge(this.iData.optionalData.attribute, data);
             this.iData.optionalData.attribute = data;
         } else {
@@ -2216,7 +2216,7 @@ function IndicatorsBatch(authentication) {
     this.tags = function(data) {
         var tag;
         // if (typeof data === 'object' && data.length != 0) {
-        if (Object.prototype.toString.call( data ) === '[object Array]' && data.length != 0) {
+        if (Object.prototype.toString.call( data ) === '[object Array]' && data.length !== 0) {
             if (!this.iData.optionalData.tag) { this.iData.optionalData.tag = []; }
             for (tag in data) {
                 this.iData.optionalData.tag.push({name: data[tag]});
@@ -2229,7 +2229,7 @@ function IndicatorsBatch(authentication) {
 
     this.associatedGroup = function(data) {
         var associatedGroup;
-        if (Object.prototype.toString.call( data ) === '[object Array]' && data.length != 0) {
+        if (Object.prototype.toString.call( data ) === '[object Array]' && data.length !== 0) {
             if (!this.iData.optionalData.associatedGroup) { this.iData.optionalData.associatedGroup = []; }
             for (associatedGroup in data) {
                 this.iData.optionalData.associatedGroup.push(data[associatedGroup]);
@@ -2279,6 +2279,7 @@ function IndicatorsBatch(authentication) {
         if (this.iData.requiredData.summary && this.iData.requiredData.type) {
             body = $.extend(this.iData.requiredData, this.iData.optionalData);
 
+            // TODO: Not sure what is going on on the lines below (1)
             specificBody = this.iData.specificData[this.iData.requiredData.type],
                 body = $.extend(body, specificBody);
 
@@ -2329,7 +2330,7 @@ function IndicatorsBatch(authentication) {
             message;
 
         // validate required fields
-        if (this.payload.owner && this.batchBody.length != 0) {
+        if (this.payload.owner && this.batchBody.length !== 0) {
 
             this.body($.extend({owner: this.payload.owner}, this.batch));
             this.normalization(normalize.default);  // bcs rename
@@ -2441,10 +2442,10 @@ function Owners(authentication) {
     RequestObject.call(this);
 
     this.authentication = authentication;
-    this.ajax.requestUri = this.ajax.baseUri + '/owners',
-    this.settings.helper = true,
-    this.settings.normalizer = normalize.owners,
-    this.settings.type = TYPE.OWNER,
+    this.ajax.requestUri = this.ajax.baseUri + '/owners';
+    this.settings.helper = true;
+    this.settings.normalizer = normalize.owners;
+    this.settings.type = TYPE.OWNER;
     this.rData = {
         id: undefined,
         optionalData: {},
@@ -2533,10 +2534,10 @@ function SecurityLabels(authentication) {
     RequestObject.call(this);
 
     this.authentication = authentication;
-    this.ajax.requestUri = this.ajax.baseUri + '/securityLabels',
-    this.settings.helper = true,
-    this.settings.normalizer = normalize.securityLabels,
-    this.settings.type = TYPE.SECURITY_LABELS,
+    this.ajax.requestUri = this.ajax.baseUri + '/securityLabels';
+    this.settings.helper = true;
+    this.settings.normalizer = normalize.securityLabels;
+    this.settings.type = TYPE.SECURITY_LABELS;
     this.rData = {
         name: undefined,
     };
@@ -2612,10 +2613,10 @@ function Tasks(authentication) {
     RequestObject.call(this);
 
     this.authentication = authentication;
-    this.ajax.requestUri = this.ajax.baseUri + '/tasks',
-    this.settings.helper = true,
-    this.settings.normalizer = normalize.tasks,
-    this.settings.type = TYPE.TASK,
+    this.ajax.requestUri = this.ajax.baseUri + '/tasks';
+    this.settings.helper = true;
+    this.settings.normalizer = normalize.tasks;
+    this.settings.type = TYPE.TASK;
     this.rData = {
         id: undefined,
         optionalData: {},
@@ -2636,7 +2637,7 @@ function Tasks(authentication) {
 
     /* TASK COMMIT OPTIONAL */
     this.assignee = function(data) {
-        if (objectCheck('assignee', data) && data.length != 0) {
+        if (objectCheck('assignee', data) && data.length !== 0) {
             this.rData.optionalData.assignee = data;
         }
         return this;
@@ -2654,7 +2655,7 @@ function Tasks(authentication) {
     };
 
     this.escalatee = function(data) {
-        if (objectCheck('escalatee', data) && data.length != 0) {
+        if (objectCheck('escalatee', data) && data.length !== 0) {
             this.rData.optionalData.escalatee = data;
         }
         return this;
@@ -3128,10 +3129,10 @@ function Tags(authentication) {
     RequestObject.call(this);
 
     this.authentication = authentication;
-    this.ajax.requestUri = this.ajax.baseUri + '/tags',
-    this.settings.helper = true,
-    this.settings.normalizer = normalize.tags,
-    this.settings.type = TYPE.TAG,
+    this.ajax.requestUri = this.ajax.baseUri + '/tags';
+    this.settings.helper = true;
+    this.settings.normalizer = normalize.tags;
+    this.settings.type = TYPE.TAG;
     this.rData = {
         name: undefined,
     };
@@ -3266,10 +3267,10 @@ function Victims(authentication) {
     RequestObject.call(this);
 
     this.authentication = authentication;
-    this.ajax.requestUri = this.ajax.baseUri + '/victims',
-    this.settings.helper = true,
-    this.settings.normalizer = normalize.victims,
-    this.settings.type = TYPE.VICTIM,
+    this.ajax.requestUri = this.ajax.baseUri + '/victims';
+    this.settings.helper = true;
+    this.settings.normalizer = normalize.victims;
+    this.settings.type = TYPE.VICTIM;
     this.rData = {
         id: undefined,
         optionalData: {},
@@ -3725,9 +3726,9 @@ function WhoAmI(authentication) {
     RequestObject.call(this);
 
     this.authentication = authentication;
-    this.ajax.requestUri = 'v2',
+    this.ajax.requestUri = 'v2';
     this.resultLimit(500);
-    this.settings.helper = true,
+    this.settings.helper = true;
     this.settings.type = TYPE.WHOAMI;
 
     /* API ACTIONS */
@@ -3844,10 +3845,10 @@ function Spaces(authentication) {
     RequestObject.call(this);
 
     this.authentication = authentication;
-    this.ajax.requestUri = this.ajax.baseUri + '/owners',
-    this.settings.helper = true,
-    this.settings.normalizer = normalize.owners,
-    this.settings.type = TYPE.OWNER,
+    this.ajax.requestUri = this.ajax.baseUri + '/owners';
+    this.settings.helper = true;
+    this.settings.normalizer = normalize.owners;
+    this.settings.type = TYPE.OWNER;
     this.sData = {
         stateParams: {},
         stateText: {},
@@ -4068,7 +4069,7 @@ var normalize = {
 
         // $.each(response, function(rkey, rvalue) {
         Array.prototype.forEach.call(response, function(rvalue, index, array){
-            if (rvalue && rvalue.length == 0) {
+            if (rvalue && rvalue.length === 0) {
                 return;
             }
 
@@ -4118,7 +4119,7 @@ var normalize = {
         var indicators = [];
         // $.each(response, function(rkey, rvalue) {
         Array.prototype.forEach.call(response, function(rvalue, index, array){
-            if (rvalue && rvalue.length == 0) {
+            if (rvalue && rvalue.length === 0) {
                 return;
             }
 
@@ -4143,7 +4144,7 @@ var normalize = {
         return observations;
     },
     observationCount: function(ro, response) {
-        var observationCount = undefined;
+        var observationCount;
 
         if (response) {
             observationCount = response.observationCount;

--- a/threatconnect.js
+++ b/threatconnect.js
@@ -4095,7 +4095,7 @@ var normalize = {
 
                 indicators.push({
                     id: rvalue.id,
-                    indicators: indicatorsData.join(' : '),
+                    indicator: indicatorsData.join(' : '),
                     dateAdded: rvalue.dateAdded,
                     lastModified: rvalue.lastModified,
                     ownerName: rvalue.ownerName || rvalue.owner.name,

--- a/threatconnect.js
+++ b/threatconnect.js
@@ -4095,7 +4095,7 @@ var normalize = {
 
                 indicators.push({
                     id: rvalue.id,
-                    indicator: indicatorsData.join(' : '),
+                    indicator: indicatorsData,
                     dateAdded: rvalue.dateAdded,
                     lastModified: rvalue.lastModified,
                     ownerName: rvalue.ownerName || rvalue.owner.name,

--- a/threatconnect.js
+++ b/threatconnect.js
@@ -2082,6 +2082,7 @@ function Indicators(authentication) {
             if (this.iData.indicator) {
                 this.requestUri([
                     this.ajax.baseUri,
+                    this.settings.type.uri,
                     this.settings.type.type == 'URL' || this.settings.type.type == 'EmailAddress' ? encodeURIComponent(this.iData.indicator) : this.iData.indicator,
                 ].join('/'));
                 this.requestMethod('PUT');

--- a/threatconnect.js
+++ b/threatconnect.js
@@ -1660,7 +1660,7 @@ function Indicators(authentication) {
         }
 
         this.requestUri([
-            this.ajax.requestUri,
+            this.ajax.baseUri,
             this.settings.type.uri,
             this.settings.type.type == 'URL' || this.settings.type.type == 'EmailAddress' ? encodeURIComponent(this.iData.indicator) : this.iData.indicator,
         ].join('/'));

--- a/threatconnect.js
+++ b/threatconnect.js
@@ -1463,6 +1463,33 @@ function Indicators(authentication) {
         return this;
     };
 
+    /* INDICATOR UTILTIY FUNCTIONS */
+
+    this._getSingleIndicatorValue = function(indicator) {
+        /* Get a single (non-null) value from the indicator Object. */
+        var indicatorValue;
+
+        // iterate through the values of the indicator Object
+        for(var indicatorField in indicator) {
+            // get the value from the indicator Object
+            indicatorValue = indicator[indicatorField];
+
+            // if the indicator value is not undefined, stop iterating through the indicator Object
+            if (indicatorValue != undefined) {
+                break;
+            }
+        }
+
+        // raise an error if the user passed in an empty Object
+        if (indicatorValue === undefined) {
+            // TODO: raise error here
+            var errorMessage = 'Request Failure: indicator is required (an empty Object was received).';
+            console.error(errorMessage);
+        } else {
+            return indicatorValue;
+        }
+    };
+
     /* API ACTIONS */
 
     // Commit
@@ -1473,9 +1500,10 @@ function Indicators(authentication) {
 
         // validate required fields
         if (this.iData.indicator) {
-            if(this.settings.type.type=='File' && this.iData.indicator.constructor == Object) {
-                for(var hash in this.iData.indicator) {
-                    this.iData.requiredData[hash] = this.iData.indicator[hash];
+            // validate the fields for the indicator
+            if(this.iData.indicator.constructor == Object) {
+                for(var indicatorField in this.iData.indicator) {
+                    this.iData.requiredData[indicatorField] = this.iData.indicator[indicatorField];
                 }
             }
             else {
@@ -1512,9 +1540,11 @@ function Indicators(authentication) {
         /* POST - /v2/indicators/{type}/{indicator}/groups/{type}/{id} */
         this.normalization(normalize.find(association.type.type));
 
-        if (this.settings.type.type=='File' && this.iData.indicator.constructor == Object) {
-            // set the indicator to one of the file hashes in the Object
-            this.iData.indicator = this._getFileHash();
+        // TODO: add an error here if no indicator is given (2)
+
+        // if the indicator is an Object, set the indicator to be one of the values in the Object
+        if(this.iData.indicator.constructor == Object) {
+            this.iData.indicator = this._getSingleIndicatorValue(this.iData.indicator);
         }
 
         this.requestUri([
@@ -1536,9 +1566,9 @@ function Indicators(authentication) {
         if (attribute) {
             this.normalization(normalize.attributes);
 
-            if(this.settings.type.type=='File' && this.iData.indicator.constructor == Object) {
-                // set the indicator to one of the file hashes in the Object
-                this.iData.indicator = this._getFileHash();
+            // if the indicator is an Object, set the indicator to be one of the values in the Object
+            if(this.iData.indicator.constructor == Object) {
+                this.iData.indicator = this._getSingleIndicatorValue(this.iData.indicator);
             }
 
             this.requestUri([
@@ -1567,9 +1597,9 @@ function Indicators(authentication) {
         /* POST - /v2/indicators/{type}/{indicator}/falsePositive */
         this.normalization(normalize.default);
 
-        if(this.settings.type.type=='File' && this.iData.indicator.constructor == Object) {
-            // set the indicator to one of the file hashes in the Object
-            this.iData.indicator = this._getFileHash();
+        // if the indicator is an Object, set the indicator to be one of the values in the Object
+        if(this.iData.indicator.constructor == Object) {
+            this.iData.indicator = this._getSingleIndicatorValue(this.iData.indicator);
         }
 
         this.requestUri([
@@ -1587,9 +1617,9 @@ function Indicators(authentication) {
     this.commitObservation = function(params) {
         /* POST - /v2/indicators/{type}/{indicator}/observation */
 
-        if(this.settings.type.type=='File' && this.iData.indicator.constructor == Object) {
-            // set the indicator to one of the file hashes in the Object
-            this.iData.indicator = this._getFileHash();
+        // if the indicator is an Object, set the indicator to be one of the values in the Object
+        if(this.iData.indicator.constructor == Object) {
+            this.iData.indicator = this._getSingleIndicatorValue(this.iData.indicator);
         }
 
         this.requestUri([
@@ -1612,9 +1642,9 @@ function Indicators(authentication) {
         /* POST - /v2/indicators/{type}/{indicator}/securityLabels/{name} */
         this.normalization(normalize.securityLabels);
 
-        if(this.settings.type.type=='File' && this.iData.indicator.constructor == Object) {
-            // set the indicator to one of the file hashes in the Object
-            this.iData.indicator = this._getFileHash();
+        // if the indicator is an Object, set the indicator to be one of the values in the Object
+        if(this.iData.indicator.constructor == Object) {
+            this.iData.indicator = this._getSingleIndicatorValue(this.iData.indicator);
         }
 
         this.requestUri([
@@ -1634,9 +1664,9 @@ function Indicators(authentication) {
         /* POST - /v2/indicators/{type}/{indicator}/tags/{name} */
         this.normalization(normalize.tags);
 
-        if(this.settings.type.type=='File' && this.iData.indicator.constructor == Object) {
-            // set the indicator to one of the file hashes in the Object
-            this.iData.indicator = this._getFileHash();
+        // if the indicator is an Object, set the indicator to be one of the values in the Object
+        if(this.iData.indicator.constructor == Object) {
+            this.iData.indicator = this._getSingleIndicatorValue(this.iData.indicator);
         }
 
         this.requestUri([
@@ -1654,9 +1684,9 @@ function Indicators(authentication) {
     // Delete
     this.delete = function() {
         /* DELETE - /v2/indicators/{type}/{indicator} */
-        if(this.settings.type.type=='File' && this.iData.indicator.constructor == Object) {
-            // set the indicator to one of the file hashes in the Object
-            this.iData.indicator = this._getFileHash();
+        // if the indicator is an Object, set the indicator to be one of the values in the Object
+        if(this.iData.indicator.constructor == Object) {
+            this.iData.indicator = this._getSingleIndicatorValue(this.iData.indicator);
         }
 
         this.requestUri([
@@ -1672,9 +1702,9 @@ function Indicators(authentication) {
     // Delete Associations
     this.deleteAssociation = function(association) {
         /* DELETE - /v2/indicators/{type}/{indicator}/groups/{type}/{id} */
-        if(this.settings.type.type=='File' && this.iData.indicator.constructor == Object) {
-            // set the indicator to one of the file hashes in the Object
-            this.iData.indicator = this._getFileHash();
+        // if the indicator is an Object, set the indicator to be one of the values in the Object
+        if(this.iData.indicator.constructor == Object) {
+            this.iData.indicator = this._getSingleIndicatorValue(this.iData.indicator);
         }
 
         this.requestUri([
@@ -1692,9 +1722,9 @@ function Indicators(authentication) {
     // Delete Attributes
     this.deleteAttribute = function(attributeId) {
         /* DELETE - /v2/indicators/{type}/{indicator}/attributes/{id} */
-        if(this.settings.type.type=='File' && this.iData.indicator.constructor == Object) {
-            // set the indicator to one of the file hashes in the Object
-            this.iData.indicator = this._getFileHash();
+        // if the indicator is an Object, set the indicator to be one of the values in the Object
+        if(this.iData.indicator.constructor == Object) {
+            this.iData.indicator = this._getSingleIndicatorValue(this.iData.indicator);
         }
 
         this.requestUri([
@@ -1712,9 +1742,9 @@ function Indicators(authentication) {
     // Delete Security Label
     this.deleteSecurityLabel = function(label) {
         /* DELETE - /v2/indicators/{type}/{indicator}/securityLabels/{name} */
-        if(this.settings.type.type=='File' && this.iData.indicator.constructor == Object) {
-            // set the indicator to one of the file hashes in the Object
-            this.iData.indicator = this._getFileHash();
+        // if the indicator is an Object, set the indicator to be one of the values in the Object
+        if(this.iData.indicator.constructor == Object) {
+            this.iData.indicator = this._getSingleIndicatorValue(this.iData.indicator);
         }
 
         this.requestUri([
@@ -1732,9 +1762,9 @@ function Indicators(authentication) {
     // Delete Tag
     this.deleteTag = function(tag) {
         /* DELETE - /v2/indicators/{type}/{indicator}/tags/{name} */
-        if(this.settings.type.type=='File' && this.iData.indicator.constructor == Object) {
-            // set the indicator to one of the file hashes in the Object
-            this.iData.indicator = this._getFileHash();
+        // if the indicator is an Object, set the indicator to be one of the values in the Object
+        if(this.iData.indicator.constructor == Object) {
+            this.iData.indicator = this._getSingleIndicatorValue(this.iData.indicator);
         }
 
         this.requestUri([
@@ -1754,6 +1784,11 @@ function Indicators(authentication) {
         /* GET - /v2/indicators/ */
         /* GET - /v2/indicators/{type} */
         /* GET - /v2/indicators/{type}/{indicator} */
+
+        // if there is an indicator and if said indicator is an Object, set the indicator to be one of the values in the Object
+        if(this.iData.indicator && this.iData.indicator.constructor == Object) {
+            this.iData.indicator = this._getSingleIndicatorValue(this.iData.indicator);
+        }
 
         // this.ajax.requestUri += '/' + this.settings.type.uri;
         this.requestUri([
@@ -1791,6 +1826,11 @@ function Indicators(authentication) {
         this.normalization(normalize.find(association.type.type));
         this.normalizationType(association.type);
 
+        // if the indicator is an Object, set the indicator to be one of the values in the Object
+        if(this.iData.indicator.constructor == Object) {
+            this.iData.indicator = this._getSingleIndicatorValue(this.iData.indicator);
+        }
+
         this.requestUri([
             this.ajax.baseUri,
             this.settings.type.uri,
@@ -1814,6 +1854,11 @@ function Indicators(authentication) {
 
         this.settings.normalizer = normalize.attributes;
 
+        // if the indicator is an Object, set the indicator to be one of the values in the Object
+        if(this.iData.indicator.constructor == Object) {
+            this.iData.indicator = this._getSingleIndicatorValue(this.iData.indicator);
+        }
+
         this.requestUri([
             this.ajax.baseUri,
             this.settings.type.uri,
@@ -1836,6 +1881,11 @@ function Indicators(authentication) {
 
         this.settings.normalizer = normalize.observations;
 
+        // if the indicator is an Object, set the indicator to be one of the values in the Object
+        if(this.iData.indicator.constructor == Object) {
+            this.iData.indicator = this._getSingleIndicatorValue(this.iData.indicator);
+        }
+
         this.requestUri([
             this.ajax.baseUri,
             this.settings.type.uri,
@@ -1852,6 +1902,11 @@ function Indicators(authentication) {
 
         this.settings.normalizer = normalize.observationCount;
 
+        // if the indicator is an Object, set the indicator to be one of the values in the Object
+        if(this.iData.indicator.constructor == Object) {
+            this.iData.indicator = this._getSingleIndicatorValue(this.iData.indicator);
+        }
+
         this.requestUri([
             this.ajax.baseUri,
             this.settings.type.uri,
@@ -1867,6 +1922,11 @@ function Indicators(authentication) {
         /* GET - /v2/indicators/{type}/{indicator}/owners */
 
         this.settings.normalizer = normalize.owners;
+
+        // if the indicator is an Object, set the indicator to be one of the values in the Object
+        if(this.iData.indicator.constructor == Object) {
+            this.iData.indicator = this._getSingleIndicatorValue(this.iData.indicator);
+        }
 
         this.requestUri([
             this.ajax.baseUri,
@@ -1891,6 +1951,11 @@ function Indicators(authentication) {
 
         this.settings.normalizer = normalize.securityLabels;
 
+        // if the indicator is an Object, set the indicator to be one of the values in the Object
+        if(this.iData.indicator.constructor == Object) {
+            this.iData.indicator = this._getSingleIndicatorValue(this.iData.indicator);
+        }
+
         this.requestUri([
             this.ajax.baseUri,
             this.settings.type.uri,
@@ -1914,6 +1979,11 @@ function Indicators(authentication) {
 
         this.settings.normalizer = normalize.tags;
 
+        // if the indicator is an Object, set the indicator to be one of the values in the Object
+        if(this.iData.indicator.constructor == Object) {
+            this.iData.indicator = this._getSingleIndicatorValue(this.iData.indicator);
+        }
+
         this.requestUri([
             this.ajax.baseUri,
             this.settings.type.uri,
@@ -1935,6 +2005,11 @@ function Indicators(authentication) {
         /* GET - /v2/indicators/{type}/{indicator}/tasks */
 
         this.settings.normalizer = normalize.tasks;
+
+        // if the indicator is an Object, set the indicator to be one of the values in the Object
+        if(this.iData.indicator.constructor == Object) {
+            this.iData.indicator = this._getSingleIndicatorValue(this.iData.indicator);
+        }
 
         this.requestUri([
             this.ajax.baseUri,
@@ -1971,6 +2046,11 @@ function Indicators(authentication) {
         if (this.settings.type == TYPE.FILE) {
             this.settings.normalizer = normalize.fileOccurrences;
 
+            // if the indicator is an Object, set the indicator to be one of the values in the Object
+            if(this.iData.indicator.constructor == Object) {
+                this.iData.indicator = this._getSingleIndicatorValue(this.iData.indicator);
+            }
+
             this.requestUri([
                 this.ajax.baseUri,
                 this.settings.type.uri,
@@ -1990,6 +2070,10 @@ function Indicators(authentication) {
 
         // validate required fields
         if (this.iData.indicator) {
+            // if the indicator is an Object, set the indicator to be one of the values in the Object
+            if(this.iData.indicator.constructor == Object) {
+                this.iData.indicator = this._getSingleIndicatorValue(this.iData.indicator);
+            }
 
             // prepare body
             var specificBody = this.iData.specificData[this.settings.type.type];

--- a/threatconnect.js
+++ b/threatconnect.js
@@ -4080,18 +4080,23 @@ var normalize = {
 
             if (typeof indicatorTypeData != 'undefined'){
                 indicatorType = indicatorTypeData.type;
-                indicatorsData = [];
+                indicatorsData = {};
                 // $.each(type.indicatorFields, function(ikey, ivalue) {
                 Array.prototype.forEach.call(type.indicatorFields, function(ivalue, index, array){
                     if ('summary' in rvalue) {
-                        indicatorsData.push(rvalue.summary);
+                        indicatorsData.summary = rvalue.summary;
                         return false;
                     } else {
                         if (rvalue[ivalue]) {
-                            indicatorsData.push(rvalue[ivalue]);
+                            indicatorsData[ivalue] = rvalue[ivalue];
                         }
                     }
                 });
+
+                // If indicator has only one element, return as str
+                if (type.indicatorFields.length == 1) {
+                    indicatorsData = indicatorsData[type.indicatorFields[0]];
+                }
 
                 indicators.push({
                     id: rvalue.id,

--- a/threatconnect.js
+++ b/threatconnect.js
@@ -4087,8 +4087,8 @@ var normalize = {
                         indicatorsData.push(rvalue.summary);
                         return false;
                     } else {
-                        if (rvalue.ivalue) {
-                            indicatorsData.push(rvalue.ivalue);
+                        if (rvalue[ivalue]) {
+                            indicatorsData.push(rvalue[ivalue]);
                         }
                     }
                 });


### PR DESCRIPTION
Fixes #16 and adds support to be able to create/delete/retrieve/update files and custom indicators which are sent as objects using the SDK.

This also updates the way indicators are returned so that file indicators (and any other custom indicators with multiple fields returned from the API) will be returned as objects.

CC #7 .