### PR TITLE
Update retrieveAttributes

### DIFF
--- a/threatconnect.js
+++ b/threatconnect.js
@@ -1253,12 +1253,13 @@ function Groups(authentication) {
             this.rData.id,
             'attributes',
         ].join('/'));
-        if (intCheck('attributeId', attributeId)) {
-            this.requestUri([
-                this.ajax.requestUri,
-                attributeId
-            ].join('/'));
-        }
+        if (attributeId != undefined)
+            if (intCheck('attributeId', attributeId)) {
+                this.requestUri([
+                    this.ajax.requestUri,
+                    attributeId
+                ].join('/'));
+            }
 
         return this.apiRequest('attribute');
     };
@@ -1820,12 +1821,13 @@ function Indicators(authentication) {
             this.settings.type.type == 'URL' || this.settings.type.type == 'EmailAddress' ? encodeURIComponent(this.iData.indicator) : this.iData.indicator,
             'attributes',
         ].join('/'));
-        if (intCheck('attributeId', attributeId)) {
-            this.requestUri([
-                this.ajax.requestUri,
-                attributeId
-            ].join('/'));
-        }
+        if (attributeId != undefined)
+            if (intCheck('attributeId', attributeId)) {
+                this.requestUri([
+                    this.ajax.requestUri,
+                    attributeId
+                ].join('/'));
+            }
 
         return this.apiRequest('attribute');
     };
@@ -2958,12 +2960,13 @@ function Tasks(authentication) {
                 this.rData.id,
                 'attributes'
             ].join('/'));
-            if (intCheck('attributeId', attributeId)) {
-                this.requestUri([
-                    this.ajax.requestUri,
-                    attributeId
-                ].join('/'));
-            }
+            if (attributeId != undefined)
+                if (intCheck('attributeId', attributeId)) {
+                    this.requestUri([
+                        this.ajax.requestUri,
+                        attributeId
+                    ].join('/'));
+                }
 
             this.requestMethod('GET');
 
@@ -3563,12 +3566,13 @@ function Victims(authentication) {
             this.rData.id,
             'attributes',
         ].join('/'));
-        if (intCheck('attributeId', attributeId)) {
-            this.requestUri([
-                this.ajax.requestUri,
-                attributeId
-            ].join('/'));
-        }
+        if (attributeId != undefined)
+            if (intCheck('attributeId', attributeId)) {
+                this.requestUri([
+                    this.ajax.requestUri,
+                    attributeId
+                ].join('/'));
+            }
 
         return this.apiRequest('attribute');
     };


### PR DESCRIPTION
Don't print the `intCheck` console warning if no `attributeId` is provided.