### PR TITLE
Adding support for includeTags and includeAttributes

### DIFF
--- a/tests/test/indicatorTest.js
+++ b/tests/test/indicatorTest.js
@@ -293,7 +293,7 @@ describe('File Indicator Specific Properties', function() {
     });
   });
   /* Test adding a file action to a file. */
-  describe('File Traffic Action', function() {
+  describe('File Traffic Action (to IP Address)', function() {
     var indicatorType = indicatorHelper('file');
 
     // create an indicator with which we will associate the file
@@ -301,6 +301,100 @@ describe('File Indicator Specific Properties', function() {
     var new_indicator = {
       indicator: '1.2.3.4',
       type: TYPE.ADDRESS
+    };
+
+    indicators.owner(testOwner)
+      .indicator(new_indicator.indicator)
+      .type(new_indicator.type)
+      .done(function(response) {
+        // make sure there are no errors
+        assert.equal(response.error, undefined);
+      })
+      .error(function(response) {
+        // make sure there are no errors
+        assert.equal(response.error, undefined);
+      });
+
+    indicators.commit();
+
+    it('should commit without error', function(done) {
+      // re-initialize instance of indicator class
+      var indicators = tc.indicators();
+
+      indicators.owner(testOwner)
+        .indicator(testFile)
+        .type(indicatorType)
+        .done(function(response) {
+          // make sure there are no errors
+          assert.equal(response.error, undefined);
+        })
+        .error(function(response) {
+          // make sure there are no errors
+          assert.equal(response.error, undefined);
+        });
+
+      indicators.commitFileAction('traffic', {
+          type: new_indicator.type,
+          id: new_indicator.indicator
+      });
+    });
+  });
+  /* Test adding a file action to a file. */
+  describe('File Traffic Action (to Host)', function() {
+    var indicatorType = indicatorHelper('file');
+
+    // create an indicator with which we will associate the file
+    var indicators = tc.indicators();
+    var new_indicator = {
+      indicator: 'example.com',
+      type: TYPE.HOST
+    };
+
+    indicators.owner(testOwner)
+      .indicator(new_indicator.indicator)
+      .type(new_indicator.type)
+      .done(function(response) {
+        // make sure there are no errors
+        assert.equal(response.error, undefined);
+      })
+      .error(function(response) {
+        // make sure there are no errors
+        assert.equal(response.error, undefined);
+      });
+
+    indicators.commit();
+
+    it('should commit without error', function(done) {
+      // re-initialize instance of indicator class
+      var indicators = tc.indicators();
+
+      indicators.owner(testOwner)
+        .indicator(testFile)
+        .type(indicatorType)
+        .done(function(response) {
+          // make sure there are no errors
+          assert.equal(response.error, undefined);
+        })
+        .error(function(response) {
+          // make sure there are no errors
+          assert.equal(response.error, undefined);
+        });
+
+      indicators.commitFileAction('traffic', {
+          type: new_indicator.type,
+          id: new_indicator.indicator
+      });
+    });
+  });
+  /* Test adding a file action to a file. */
+  describe('File Traffic Action (to URL)', function() {
+    var indicatorType = indicatorHelper('file');
+
+    // create an indicator with which we will associate the file
+    var indicators = tc.indicators();
+    var new_indicator = {
+      indicator: 'http://example.com',
+      type: TYPE.URL
     };
 
     indicators.owner(testOwner)

--- a/threatconnect.js
+++ b/threatconnect.js
@@ -2804,7 +2804,7 @@ function Tasks(authentication) {
     };
 
     this.status = function(data) {
-        if (valueCheck('status', data, ['Not Started', 'In Progress', 'Complete', 'Waiting on Someone', 'Deferred'])) {
+        if (valueCheck('status', data, ['Not Started', 'In Progress', 'Completed', 'Waiting on Someone', 'Deferred'])) {
             this.rData.optionalData.status = data;
         }
         return this;
@@ -4416,6 +4416,6 @@ var valueCheck = function(name, value, array) {
     if ($.inArray(value, array) != -1) {
         return true;
     }
-    console.warn(name + ' must be of value (.' + array.join(',') + ').');
+    console.warn(name + ' must be of value (' + array.join(',') + ').');
     return false;
 };

--- a/threatconnect.js
+++ b/threatconnect.js
@@ -1639,7 +1639,7 @@ function Indicators(authentication) {
             'actions',
             fileAction,
             association.type.uri,
-            association.id,
+            association.type.type == 'URL' || association.type.type == 'EmailAddress' ? encodeURIComponent(association.id) : association.id,
         ].join('/'));
         this.requestMethod('POST');
 

--- a/threatconnect.js
+++ b/threatconnect.js
@@ -865,6 +865,28 @@ function Groups(authentication) {
         },
     };
 
+    /* GROUP QUERY STRING PARAMETERS */
+    this.includeAdditional = function(data) {
+        if (boolCheck('includeAdditional', data)) {
+            this.addPayload('includeAdditional', data);
+        }
+        return this;
+    };
+
+    this.includeAttributes = function(data) {
+        if (boolCheck('includeAttributes', data)) {
+            this.addPayload('includeAttributes', data);
+        }
+        return this;
+    };
+
+    this.includeTags = function(data) {
+        if (boolCheck('includeTags', data)) {
+            this.addPayload('includeTags', data);
+        }
+        return this;
+    };
+
     /* SETTINGS API */
     this.id = function(data) {
         this.rData.id = data;
@@ -1388,10 +1410,24 @@ function Indicators(authentication) {
         },
     };
 
-    /* INDICATOR SPECIFIC QUERY STRING PARAMETER */
+    /* INDICATOR QUERY STRING PARAMETERS */
     this.includeAdditional = function(data) {
         if (boolCheck('includeAdditional', data)) {
             this.addPayload('includeAdditional', data);
+        }
+        return this;
+    };
+
+    this.includeAttributes = function(data) {
+        if (boolCheck('includeAttributes', data)) {
+            this.addPayload('includeAttributes', data);
+        }
+        return this;
+    };
+
+    this.includeTags = function(data) {
+        if (boolCheck('includeTags', data)) {
+            this.addPayload('includeTags', data);
         }
         return this;
     };
@@ -4184,6 +4220,8 @@ var normalize = {
                     confidence: rvalue.confidence,
                     observationCount: rvalue.observationCount,
                     falsePositiveCount: rvalue.falsePositiveCount,
+                    attribute: rvalue.attribute,
+                    tag: rvalue.tag,
                     type: indicatorType,
                     threatAssessRating: rvalue.threatAssessRating,
                     threatAssessConfidence: rvalue.threatAssessConfidence,


### PR DESCRIPTION
Adding support for the new functionality to retrieve attributes and tags with a request: https://docs.threatconnect.com/en/latest/rest_api/overview.html#retrieving-an-item-s-tags-and-attributes .