### PR TITLE
Adding handling for requests to custom metrics

### DIFF
--- a/threatconnect.js
+++ b/threatconnect.js
@@ -615,6 +615,15 @@ function RequestObject() {
                     responseContentType = request.getResponseHeader('Content-Type');
 
                 _this.response.apiCalls++;
+             
+                // handle responses from custom metrics
+                if (params === 'customMetric') {
+                    // make sure the request went through successfully
+                    if (response.date) {
+                        response.status = "Success";
+                    }
+                }
+
                 _this.response.status = response.status;
 
                 if (response.status == 'Success' && response.data) {


### PR DESCRIPTION
A post request to the custom metrics API doesn't return a status. I've added handling to detect if a custom metric request was made and if it was successful.